### PR TITLE
♻️refactor(socket.config.ts): 클라이언트의 socket.io 설정을 websocket만 사용하게 변경

### DIFF
--- a/client/src/stores/socket/socket.config.ts
+++ b/client/src/stores/socket/socket.config.ts
@@ -82,6 +82,7 @@ export const SOCKET_CONFIG = {
     reconnection: true,
     reconnectionAttempts: 5,
     reconnectionDelay: 1000,
+    transports: ['websocket'],
   },
   /** 네임스페이스별 경로 */
   PATHS: {


### PR DESCRIPTION
## 📂 작업 내용

- [x] FE 코드에 socket io의 내부 프로토콜을 websocket만 사용하게 강제함.

## 💡 자세한 설명

- FE 코드에서 websocket만 강제하게 하는 설정을 찾지 못해 제대로 설정하지 못함.
- https://docs.nestjs.com/websockets/adapter 이 문서를 참조해 설정.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
