### PR TITLE
📦ci: 멀티 서버 대응

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  server:
+  server1:
     image: ${DOCKERHUB_USERNAME}/troublepainter-server:latest
-    container_name: troublepainter_server
+    container_name: server1
     environment:
       - NODE_ENV=production
       - REDIS_HOST=${REDIS_HOST}
@@ -10,6 +10,23 @@ services:
       - CLOVA_GATEWAY_KEY=${CLOVA_GATEWAY_KEY}
     networks:
       - app_network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  server2:
+    image: ${DOCKERHUB_USERNAME}/troublepainter-server:latest
+    container_name: server2
+    environment:
+      - NODE_ENV=production
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - CLOVA_API_KEY=${CLOVA_API_KEY}
+      - CLOVA_GATEWAY_KEY=${CLOVA_GATEWAY_KEY}
+    networks:
+      - app_network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
 
   nginx:
@@ -17,11 +34,13 @@ services:
     container_name: troublepainter_nginx
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
+      - nginx.conf:/etc/nginx/templates/default.conf.template
     ports:
       - "80:80"
       - "443:443"
     depends_on:
-      - server
+      - server1
+      - server2
     networks:
       - app_network
     restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,4 @@
-upstream rr {
+upstream load_balance {
     ip_hash;
     server server1:3000;
     server server2:3000;
@@ -26,14 +26,14 @@ server {
     }
 
     location /api {
-        proxy_pass http://rr;
+        proxy_pass http://load_balance;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
 
     location /socket.io {
-        proxy_pass http://rr;
+        proxy_pass http://load_balance;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 upstream rr {
-    hash $remote_addr consistent;
+    ip_hash;
     server server1:3000;
     server server2:3000;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,9 @@
+upstream rr {
+    hash $remote_addr consistent;
+    server server1:3000;
+    server server2:3000;
+}
+
 server {
     listen 80;
     server_name re-troublepainter.kro.kr;
@@ -20,17 +26,18 @@ server {
     }
 
     location /api {
-        proxy_pass http://server:3000;
+        proxy_pass http://rr;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
 
     location /socket.io {
-        proxy_pass http://server:3000;
+        proxy_pass http://rr;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
     }
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #50 

- [x] 백엔드 docker container 를 두개 띄움.

## 💡 자세한 설명

docker-compose와 nginx.conf 설정을 변경함.
docker-compose에서 백엔드 서버를 2개를 바탕으로 구현
nginx.conf에서 각 유저는 ip hashing을 통해 2개의 백엔드 서버에 각각 배분됨.

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
