### PR TITLE
Feature/#48 서버에서 가상 캔버스에 그림 그리기

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       jest-mock:
         specifier: ^29.7.0
         version: 29.7.0
+      pureimage:
+        specifier: ^0.4.18
+        version: 0.4.18
       redis:
         specifier: ^4.7.0
         version: 4.7.0
@@ -2638,11 +2641,11 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/lodash@4.17.14':
-    resolution: {integrity: sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==}
-
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/lodash@4.17.14':
+    resolution: {integrity: sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -5428,6 +5431,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -6129,6 +6135,10 @@ packages:
     resolution: {integrity: sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==}
     engines: {node: '>=0.10'}
 
+  opentype.js@0.4.11:
+    resolution: {integrity: sha512-GthxucX/6aftfLdeU5Ho7o7zmQcC8uVtqdcelVq12X++ndxwBZG8Xb5rFEKT7nEcWDD2P1x+TNuJ70jtj1Mbpw==}
+    hasBin: true
+
   opn@5.5.0:
     resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
     engines: {node: '>=4'}
@@ -6585,6 +6595,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pureimage@0.4.18:
+    resolution: {integrity: sha512-piyNT+J1bISJMHxz3VYUvgGLpQAa2NEt5nDdEIozO5Jhla0/jI/atSWFoRVTNrD5KosCMJSghohnqoIjWV0LEw==}
+    engines: {node: '>=14.19.0'}
 
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
@@ -11326,11 +11340,11 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/lodash@4.17.14': {}
-
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 22.9.1
+
+  '@types/lodash@4.17.14': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -15080,6 +15094,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  jpeg-js@0.4.4: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -15782,6 +15798,8 @@ snapshots:
 
   opentracing@0.14.7: {}
 
+  opentype.js@0.4.11: {}
+
   opn@5.5.0:
     dependencies:
       is-wsl: 1.1.0
@@ -16193,6 +16211,12 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pureimage@0.4.18:
+    dependencies:
+      jpeg-js: 0.4.4
+      opentype.js: 0.4.11
+      pngjs: 7.0.0
 
   q@1.5.1: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
     "axios": "^1.7.7",
     "ioredis": "^5.4.1",
     "jest-mock": "^29.7.0",
+    "pureimage": "^0.4.18",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/server/src/common/services/canvas.service.spec.ts
+++ b/server/src/common/services/canvas.service.spec.ts
@@ -1,0 +1,98 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CanvasService } from './canvas.service';
+import { CRDTMessage, CRDTMessageTypes } from '@troublepainter/core';
+
+const PLAYER_IDS = ['1', '2', '3'];
+const CRDT_DATAS = Array.from({ length: 10 }, (_, index) => {
+  return {
+    playerId: PLAYER_IDS[index % 3],
+    drawingData: {
+      type: CRDTMessageTypes.UPDATE,
+      state: {
+        key: `${PLAYER_IDS[index % 3]}-${index * 10}-${index}`,
+        register: {
+          peerId: PLAYER_IDS[index % 3],
+          timestamp: index * 10,
+          value: {
+            points: [
+              {
+                x: index * 100,
+                y: index * 60,
+              },
+              {
+                x: (index + 1) * 100,
+                y: (index + 1) * 60,
+              },
+            ],
+            style: {
+              color: '#ff0000',
+              width: 4,
+            },
+            timestamp: index * 10,
+          },
+          isDeactivated: false,
+        },
+      },
+    },
+  };
+}) as { playerId: string; drawingData: CRDTMessage }[];
+
+describe('CanvasService', () => {
+  let service: CanvasService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CanvasService],
+    }).compile();
+
+    service = module.get<CanvasService>(CanvasService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createRoom', () => {
+    it('should create a new room', () => {
+      service.createRoom('room1');
+      expect(service['crdtMap'].has('room1')).toBe(true);
+    });
+  });
+
+  describe('removeRoom', () => {
+    it('should remove the existing room', () => {
+      service.createRoom('room1');
+      service.removeRoom('room1');
+      expect(service['crdtMap'].has('room1')).toBe(false);
+    });
+  });
+
+  describe('applyDrawing', () => {
+    it('should update CRDT state when a drawing is applied', () => {
+      service.createRoom('room1');
+
+      for (const crdtDate of CRDT_DATAS) {
+        service.applyDrawing('room1', crdtDate.drawingData);
+      }
+      expect(service['crdtMap'].get('room1').getActiveStrokes().length).toBe(10);
+    });
+  });
+
+  describe('getImagesByBase64', () => {
+    it('should return base64 encoded images', async () => {
+      service.createRoom('room1');
+
+      for (const crdtDate of CRDT_DATAS) {
+        service.applyDrawing('room1', crdtDate.drawingData);
+      }
+
+      const result = await service.getImagesByBase64('room1');
+      // 개인 캔버스
+      PLAYER_IDS.forEach((playerId) => {
+        expect(typeof result[playerId]).toBe('string');
+      });
+      // 공용 캔버스
+      expect(typeof result['shared']).toBe('string');
+    }, 20000);
+  });
+});

--- a/server/src/common/services/canvas.service.ts
+++ b/server/src/common/services/canvas.service.ts
@@ -74,13 +74,13 @@ export class CanvasService {
 
     //그림을 base64 이미지로 변환
     const canvasList = [sharedCanvas, ...Object.values(individualCanvasMap).map(({ canvas }) => canvas)];
-    const resultKeyList = [null, ...Object.keys(individualCanvasMap)];
+    const resultKeyList = ['shared', ...Object.keys(individualCanvasMap)];
     const resultValueList = await Promise.all(
       canvasList.map(async (canvas) => {
         const passThroughStream = new PassThrough();
         const pngData = [];
         passThroughStream.on('data', (chunk) => pngData.push(chunk));
-        await PImage.encodePNGToStream(canvas, passThroughStream);
+        await PImage.encodeJPEGToStream(canvas, passThroughStream);
         const buf = Buffer.concat(pngData);
         return buf.toString('base64');
       }),

--- a/server/src/common/services/canvas.service.ts
+++ b/server/src/common/services/canvas.service.ts
@@ -56,6 +56,8 @@ export class CanvasService {
 
     const sharedCanvas = PImage.make(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
     const sharedCtx = sharedCanvas.getContext('2d');
+    sharedCtx.fillStyle = 'white';
+    sharedCtx.fillRect(0, 0, MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
     const individualCanvasMap: Record<string, { canvas: PImage.Bitmap; ctx: PImage.Context }> = {};
 
     // 그림 그리기
@@ -67,6 +69,8 @@ export class CanvasService {
       if (!individualCanvasMap[playerId]) {
         const canvas = PImage.make(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
         const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'white';
+        ctx.fillRect(0, 0, MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
         individualCanvasMap[playerId] = { canvas, ctx };
       }
       this.drawStroke(individualCanvasMap[playerId].ctx, stroke);

--- a/server/src/common/services/canvas.service.ts
+++ b/server/src/common/services/canvas.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { LWWMap, CRDTMessage, CRDTMessageTypes } from '@troublepainter/core';
+import { DrawingData } from '@troublepainter/core';
+import * as PImage from 'pureimage';
+import { PassThrough } from 'stream';
+
+@Injectable()
+export class CanvasService {
+  private crdtMap: Map<string, LWWMap> = new Map();
+
+  createRoom(roomId: string) {
+    this.crdtMap.set(roomId, new LWWMap(roomId));
+  }
+  removeRoom(roomID: string) {
+    this.crdtMap.delete(roomID);
+  }
+
+  // 선 그리기
+  private drawStroke = (ctx: PImage.Context, drawingData: DrawingData) => {
+    const { points, style } = drawingData;
+    if (points.length === 0) return;
+    ctx.strokeStyle = style.color;
+    ctx.fillStyle = style.color;
+    ctx.lineWidth = style.width;
+    ctx.beginPath();
+    if (points.length === 1) {
+      const point = points[0];
+      ctx.arc(point.x, point.y, style.width / 2, 0, Math.PI * 2);
+      ctx.fill();
+    } else {
+      ctx.moveTo(points[0].x, points[0].y);
+      points.slice(1).forEach((point) => ctx.lineTo(point.x, point.y));
+      ctx.stroke();
+    }
+  };
+
+  // 드로잉 데이터를 적용
+  applyDrawing(roomId: string, crdtDrawingData: CRDTMessage) {
+    const lwwMap = this.crdtMap.get(roomId);
+    if (!lwwMap) return;
+
+    if (crdtDrawingData.type === CRDTMessageTypes.UPDATE) {
+      const { key, register } = crdtDrawingData.state;
+      lwwMap.mergeRegister(key, register);
+    }
+  }
+
+  // 캔버스 이미지를 base64로 변환
+  async getImagesByBase64(roomId: string): Promise<Record<string, string>> {
+    const lwwMap = this.crdtMap.get(roomId);
+    if (!lwwMap) return;
+    const lwwMapState = lwwMap.state;
+
+    const MAINCANVAS_RESOLUTION_WIDTH = 1000;
+    const MAINCANVAS_RESOLUTION_HEIGHT = 625;
+
+    const sharedCanvas = PImage.make(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
+    const sharedCtx = sharedCanvas.getContext('2d');
+    const individualCanvasMap: Record<string, { canvas: PImage.Bitmap; ctx: PImage.Context }> = {};
+
+    // 그림 그리기
+    const activeStrokes = lwwMap.getActiveStrokes();
+    for (const { stroke, id } of activeStrokes) {
+      const playerId = lwwMapState[id].peerId;
+      if (stroke.points.length > 2) return; // 채우기는 제외
+      this.drawStroke(sharedCtx, stroke);
+      if (!individualCanvasMap[playerId]) {
+        const canvas = PImage.make(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
+        const ctx = canvas.getContext('2d');
+        individualCanvasMap[playerId] = { canvas, ctx };
+      }
+      this.drawStroke(individualCanvasMap[playerId].ctx, stroke);
+    }
+
+    //그림을 base64 이미지로 변환
+    const canvasList = [sharedCanvas, ...Object.values(individualCanvasMap).map(({ canvas }) => canvas)];
+    const resultKeyList = [null, ...Object.keys(individualCanvasMap)];
+    const resultValueList = await Promise.all(
+      canvasList.map(async (canvas) => {
+        const passThroughStream = new PassThrough();
+        const pngData = [];
+        passThroughStream.on('data', (chunk) => pngData.push(chunk));
+        await PImage.encodePNGToStream(canvas, passThroughStream);
+        const buf = Buffer.concat(pngData);
+        return buf.toString('base64');
+      }),
+    );
+
+    return resultKeyList.reduce((acc, key, idx) => {
+      acc[key] = resultValueList[idx];
+      return acc;
+    }, {});
+  }
+}


### PR DESCRIPTION
## 📂 작업 내용

closes #48 

- [x] pureimage 설치
- [x] 게임 방마다 LWWMap 관리
- [x] 각 플레어어마다 캔버스에 그림을 그리고 이를 base64 형식의 jpeg 이미지로 변경

## 💡 자세한 설명

<https://www.notion.so/j-i-n/0204-4e20ef3862d843649536cd99fde57292>

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
