### PR TITLE
fix: 다른 사람의 그림이 안보이는 오류 해결

### DIFF
--- a/client/src/hooks/socket/useDrawingSocket.ts
+++ b/client/src/hooks/socket/useDrawingSocket.ts
@@ -91,19 +91,14 @@ export const useDrawingSocket = ({ onDrawUpdate, onSubmitRequest }: UseDrawingSo
   // 이벤트 리스너 설정
   useEffect(() => {
     const drawingSocket = sockets.drawing;
-    const gameSocket = sockets.game;
 
-    if (!drawingSocket || !gameSocket) return;
+    if (!drawingSocket) return;
 
     // drawing 네임스페이스 이벤트
     drawingSocket.on('drawUpdated', handleDrawUpdate);
 
-    // game 네임스페이스 이벤트
-    gameSocket.on('submitDrawing', handleSubmitDrawing);
-
     return () => {
       drawingSocket.off('drawUpdated', handleDrawUpdate);
-      gameSocket.off('submitDrawing', handleSubmitDrawing);
     };
   }, [sockets.drawing, sockets.game, handleDrawUpdate, handleSubmitDrawing]);
 


### PR DESCRIPTION
## 📂 작업 내용

closes #이슈번호

![image](https://github.com/user-attachments/assets/fa1ae548-75eb-4b38-9281-5f0903ff255c)

gameSocket이 sharedWorker로 옮겨가 항상 null임 

- [x] 작업 내용

## 💡 자세한 설명

(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
