### PR TITLE
Refactor/#63 캔버스 내 글자 지우는 부분을 비동기로 변경

### DIFF
--- a/server/src/drawing/drawing.gateway.ts
+++ b/server/src/drawing/drawing.gateway.ts
@@ -40,6 +40,10 @@ export class DrawingGateway implements OnGatewayConnection {
     });
   }
 
+  async beforeApplicationShutdown() {
+    await this.redisService.punsubscribe('erasing:*');
+  }
+
   async handleConnection(client: Socket) {
     const roomId = client.handshake.auth.roomId;
     const playerId = client.handshake.auth.playerId;

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -152,33 +152,34 @@ export class GameGateway implements OnGatewayDisconnect {
     // drawing 시간이 종료되면, 이미지를 base64로 변환
     const canvasImages = await this.canvasService.getImagesByBase64(roomId);
 
-    for (const [playerId, imageBase64] of Object.entries(canvasImages)) {
-      const ocrResult = await this.clovaOcr.doOCR(imageBase64);
+    await Promise.all(
+      Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
+        const ocrResult = await this.clovaOcr.doOCR(imageBase64);
 
-      // OCR 결과에서 텍스트 영역의 좌표 추출
-      const boundaries =
-        ocrResult.images[0].fields.map((field) => ({
-          playerId,
-          boundary: [
-            { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
-            { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
-            { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
-            { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
-          ],
-        })) || [];
-
-      if (boundaries.length > 0) {
-        // 텍스트가 있는 영역의 선 지우기
-        const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
-        await this.redisService.publish(
-          `erasing:${roomId}`,
-          JSON.stringify({
+        const boundaries =
+          ocrResult.images[0].fields.map((field) => ({
             playerId,
-            drawingData: eraseMessage,
-          }),
-        );
-      }
-    }
+            boundary: [
+              { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
+              { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
+              { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
+              { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
+            ],
+          })) || [];
+
+        if (boundaries.length > 0) {
+          // 텍스트가 있는 영역의 선 지우기
+          const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
+          await this.redisService.publish(
+            `erasing:${roomId}`,
+            JSON.stringify({
+              playerId,
+              drawingData: eraseMessage,
+            }),
+          );
+        }
+      }),
+    );
 
     await this.runTimer(roomId, 15000, TimerType.GUESSING);
     const result = await this.gameService.handleGuessingTimeout(roomId);


### PR DESCRIPTION
## 📂 작업 내용

closes #63 

- [x] 가상 캔버스 이미지 처리 방식을 비동기로 변경
- [x] 서버가 종료될 때 구독 해제하는 로직 추가

## 💡 자세한 설명

기존 코드에서는 가상 캔버스 이미지를 불러와 동기적인 방식으로 OCR 및 선 삭제를 진행했는데 속도를 향상시키기 위해 비동기 방식으로 변경하였습니다.
```tsx
const timerPromise = this.runTimer(roomId, 15000, TimerType.OCR);
const processingTimerPromise = (async () => {
  // drawing 시간이 종료되면, 이미지를 base64로 변환
  const canvasImages = await this.canvasService.getImagesByBase64(roomId);

  await Promise.all(
    Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
      const ocrResult = await this.clovaOcr.doOCR(imageBase64);

      const boundaries =
        ocrResult.images[0].fields.map((field) => ({
          playerId,
          boundary: [
            { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
            { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
            { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
            { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
          ],
        })) || [];

      if (boundaries.length > 0) {
        // 텍스트가 있는 영역의 선 지우기
        const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
        await this.redisService.publish(
          `erasing:${roomId}`,
          JSON.stringify({
            playerId,
            drawingData: eraseMessage,
          }),
        );
      }
    }),
  );
})();
await Promise.all([timerPromise, processingTimerPromise]);
```

시간은 임의로 15초로 잡았고, 15초 동안 해당 상태에서 머무를 수 있게 **`Promise.all()`** 로 실행하였습니다.
- 다시 말씀드리지만 시간은 임의로!!! 더 짧게(10초 이내) 변경해도 될 것 같습니다. 서버 성능에 따라 5초까지도 괜찮을 것 같아요!

(+) 성능 테스트가 완료되면 직접 머지 눌러주시면 될 것 같습니다!!!

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
