### PR TITLE
Feature/#64 OCR 탐지 시간 동안 캔버스 이미지를 보여주지 않게 하는 기능 추가

### DIFF
--- a/client/src/components/quiz/QuizStage.tsx
+++ b/client/src/components/quiz/QuizStage.tsx
@@ -1,12 +1,12 @@
-import { useMemo } from 'react';
-import { PlayerRole, RoomStatus } from '@troublepainter/core';
-import { GameCanvas } from '../canvas/GameCanvas';
-import { QuizTitle } from '../ui/QuizTitle';
+import {useMemo} from 'react';
+import {PlayerRole, RoomStatus} from '@troublepainter/core';
+import {GameCanvas} from '../canvas/GameCanvas';
+import {QuizTitle} from '../ui/QuizTitle';
 import sizzlingTimer from '@/assets/big-timer.gif';
-import { DEFAULT_MAX_PIXELS } from '@/constants/canvasConstants';
-import { useTimer } from '@/hooks/useTimer';
-import { useGameSocketStore } from '@/stores/socket/gameSocket.store';
-import { cn } from '@/utils/cn';
+import {DEFAULT_MAX_PIXELS} from '@/constants/canvasConstants';
+import {useTimer} from '@/hooks/useTimer';
+import {useGameSocketStore} from '@/stores/socket/gameSocket.store';
+import {cn} from '@/utils/cn';
 
 const QuizStageContainer = () => {
   const room = useGameSocketStore((state) => state.room);
@@ -20,12 +20,22 @@ const QuizStageContainer = () => {
   const shouldHideCanvas = useMemo(() => {
     const isGuesser = roundAssignedRole === PlayerRole.GUESSER;
     const isDrawing = room?.status === 'DRAWING';
+    const isOCR = room?.status === 'OCR';
+
+    // OCR일 경우 Canvas를 Hidden으로 설정해야 함
+    if (isOCR) return true;
+
     return isGuesser && isDrawing;
   }, [roundAssignedRole, room?.status]);
 
   const shouldHideQuizTitle = useMemo(() => {
     const isGuesser = roundAssignedRole === PlayerRole.GUESSER;
     const isDrawing = room?.status === 'DRAWING';
+    const isOCR = room?.status === 'OCR';
+
+    // OCR일 경우 QuizTitle을 Hidden으로 설정해야 함
+    if (isOCR) return true;
+
     return isGuesser && isDrawing;
   }, [roundAssignedRole, room?.status]);
 
@@ -33,6 +43,11 @@ const QuizStageContainer = () => {
     const isPainters = roundAssignedRole === PlayerRole.DEVIL || roundAssignedRole === PlayerRole.PAINTER;
     const isDrawing = room?.status === 'DRAWING';
     const isGuessing = room?.status === 'GUESSING';
+    const isOCR = room?.status === 'OCR';
+
+    // OCR 때는 모든 플레이어에게 타이머를 표시해야 함
+    if (isOCR) return false;
+
     return (isPainters && isDrawing) || isGuessing;
   }, [roundAssignedRole, room?.status]);
 
@@ -40,6 +55,8 @@ const QuizStageContainer = () => {
     switch (room?.status) {
       case 'DRAWING':
         return timers.DRAWING ?? roomSettings?.drawTime;
+      case 'OCR':
+        return timers.OCR ?? 15;
       case 'GUESSING':
         return timers.GUESSING ?? 15;
       default:
@@ -56,17 +73,24 @@ const QuizStageContainer = () => {
     }
   }, [room.status, room.currentWord, roundAssignedRole]);
 
+  const timerText = useMemo(() => {
+    if (room.status === 'OCR') {
+      return '그림을 분석하는 중...';
+    }
+    return '화가들이 실력을 뽐내는 중...';
+  }, [room.status]);
+
   return (
     <>
       {/* 구경꾼 전용 타이머 */}
       <div className={cn(shouldHideSizzlingTimer && 'hidden')}>
         <p className="mb-3 text-center text-xl text-eastbay-50 text-stroke-md sm:mb-0 sm:text-2xl lg:text-3xl">
-          화가들이 실력을 뽐내는중...
+          {timerText}
         </p>
         <div className="relative">
           <img src={sizzlingTimer} alt="구경꾼 전용 타이머" width={450} />
           <span className="absolute left-[42%] top-[45%] text-6xl text-stroke-md lg:text-7xl">
-            {timers.DRAWING ?? roomSettings.drawTime - 5}
+            {room.status === 'DRAWING' ? (timers.DRAWING ?? roomSettings.drawTime - 5) : (timers.OCR ?? 15)}
           </span>
         </div>
       </div>

--- a/client/src/hooks/socket/useGameSocket.ts
+++ b/client/src/hooks/socket/useGameSocket.ts
@@ -187,6 +187,11 @@ export const useGameSocket = () => {
       },
 
       drawingTimeEnded: () => {
+        gameActions.updateRoomStatus(RoomStatus.OCR);
+        timerActions.updateTimer(TimerType.OCR, 15);
+      },
+
+      ocrTimeEnded: () => {
         gameActions.updateRoomStatus(RoomStatus.GUESSING);
         timerActions.updateTimer(TimerType.GUESSING, 15);
       },

--- a/client/src/hooks/useTimer.ts
+++ b/client/src/hooks/useTimer.ts
@@ -8,6 +8,7 @@ export const useTimer = () => {
 
   const intervalRefs = useRef<Record<TimerType, NodeJS.Timeout | null>>({
     [TimerType.DRAWING]: null,
+    [TimerType.OCR]: null,
     [TimerType.GUESSING]: null,
     [TimerType.ENDING]: null,
   });
@@ -43,6 +44,7 @@ export const useTimer = () => {
     };
   }, [
     timers.DRAWING !== null && timers.DRAWING > 0,
+    timers.OCR !== null && timers.OCR > 0,
     timers.GUESSING !== null && timers.GUESSING > 0,
     timers.ENDING !== null && timers.ENDING > 0,
     actions,

--- a/core/types/game.types.ts
+++ b/core/types/game.types.ts
@@ -34,12 +34,14 @@ export enum RoomStatus {
   WAITING = 'WAITING',
   DRAWING = 'DRAWING',
   GUESSING = 'GUESSING',
+  OCR = 'OCR',
 }
 
 export enum TimerType {
   DRAWING = 'DRAWING',
   GUESSING = 'GUESSING',
   ENDING = 'ENDING',
+  OCR = 'OCR',
 }
 
 export enum TerminationType {

--- a/server/src/common/enums/game.status.enum.ts
+++ b/server/src/common/enums/game.status.enum.ts
@@ -13,6 +13,7 @@ export enum RoomStatus {
   WAITING = 'WAITING',
   DRAWING = 'DRAWING',
   GUESSING = 'GUESSING',
+  OCR = 'OCR',
 }
 
 export enum Difficulty {

--- a/server/src/common/enums/game.timer.enum.ts
+++ b/server/src/common/enums/game.timer.enum.ts
@@ -2,4 +2,5 @@ export enum TimerType {
   DRAWING = 'DRAWING',
   GUESSING = 'GUESSING',
   ENDING = 'ENDING',
+  OCR = 'OCR',
 }

--- a/server/src/drawing/drawing.gateway.ts
+++ b/server/src/drawing/drawing.gateway.ts
@@ -40,6 +40,10 @@ export class DrawingGateway implements OnGatewayConnection {
     });
   }
 
+  async beforeApplicationShutdown() {
+    await this.redisService.punsubscribe('erasing:*');
+  }
+
   async handleConnection(client: Socket) {
     const roomId = client.handshake.auth.roomId;
     const playerId = client.handshake.auth.playerId;

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -152,33 +152,34 @@ export class GameGateway implements OnGatewayDisconnect {
     // drawing 시간이 종료되면, 이미지를 base64로 변환
     const canvasImages = await this.canvasService.getImagesByBase64(roomId);
 
-    for (const [playerId, imageBase64] of Object.entries(canvasImages)) {
-      const ocrResult = await this.clovaOcr.doOCR(imageBase64);
+    await Promise.all(
+      Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
+        const ocrResult = await this.clovaOcr.doOCR(imageBase64);
 
-      // OCR 결과에서 텍스트 영역의 좌표 추출
-      const boundaries =
-        ocrResult.images[0].fields.map((field) => ({
-          playerId,
-          boundary: [
-            { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
-            { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
-            { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
-            { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
-          ],
-        })) || [];
-
-      if (boundaries.length > 0) {
-        // 텍스트가 있는 영역의 선 지우기
-        const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
-        await this.redisService.publish(
-          `erasing:${roomId}`,
-          JSON.stringify({
+        const boundaries =
+          ocrResult.images[0].fields.map((field) => ({
             playerId,
-            drawingData: eraseMessage,
-          }),
-        );
-      }
-    }
+            boundary: [
+              { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
+              { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
+              { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
+              { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
+            ],
+          })) || [];
+
+        if (boundaries.length > 0) {
+          // 텍스트가 있는 영역의 선 지우기
+          const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
+          await this.redisService.publish(
+            `erasing:${roomId}`,
+            JSON.stringify({
+              playerId,
+              drawingData: eraseMessage,
+            }),
+          );
+        }
+      }),
+    );
 
     await this.runTimer(roomId, 15000, TimerType.GUESSING);
     const result = await this.gameService.handleGuessingTimeout(roomId);

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -144,42 +144,53 @@ export class GameGateway implements OnGatewayDisconnect {
 
     await this.runTimer(roomId, roomSettings.drawTime * 1000, TimerType.DRAWING);
 
-    const roomStatus = await this.gameService.handleDrawingTimeout(roomId);
+    // drawing 시간이 종료되면 OCR 및 선 삭제하는 시간으로 변경할 수 있도록 수정
+    let roomStatus = await this.gameService.handleDrawingTimeout(roomId);
     this.server.to(roomId).emit('drawingTimeEnded', {
       roomStatus,
     });
 
-    // drawing 시간이 종료되면, 이미지를 base64로 변환
-    const canvasImages = await this.canvasService.getImagesByBase64(roomId);
+    const timerPromise = this.runTimer(roomId, 15000, TimerType.OCR);
+    const processingTimerPromise = (async () => {
+      // drawing 시간이 종료되면, 이미지를 base64로 변환
+      const canvasImages = await this.canvasService.getImagesByBase64(roomId);
 
-    await Promise.all(
-      Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
-        const ocrResult = await this.clovaOcr.doOCR(imageBase64);
+      await Promise.all(
+        Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
+          const ocrResult = await this.clovaOcr.doOCR(imageBase64);
 
-        const boundaries =
-          ocrResult.images[0].fields.map((field) => ({
-            playerId,
-            boundary: [
-              { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
-              { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
-              { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
-              { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
-            ],
-          })) || [];
-
-        if (boundaries.length > 0) {
-          // 텍스트가 있는 영역의 선 지우기
-          const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
-          await this.redisService.publish(
-            `erasing:${roomId}`,
-            JSON.stringify({
+          const boundaries =
+            ocrResult.images[0].fields.map((field) => ({
               playerId,
-              drawingData: eraseMessage,
-            }),
-          );
-        }
-      }),
-    );
+              boundary: [
+                { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
+                { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
+                { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
+                { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
+              ],
+            })) || [];
+
+          if (boundaries.length > 0) {
+            // 텍스트가 있는 영역의 선 지우기
+            const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
+            await this.redisService.publish(
+              `erasing:${roomId}`,
+              JSON.stringify({
+                playerId,
+                drawingData: eraseMessage,
+              }),
+            );
+          }
+        }),
+      );
+    })();
+    await Promise.all([timerPromise, processingTimerPromise]);
+
+    // OCR 및 선 삭제 로직이 종료된 이후 추측 시간으로 변경
+    roomStatus = await this.gameService.handleOCRTimeout(roomId);
+    this.server.to(roomId).emit('ocrTimeEnded', {
+      roomStatus,
+    });
 
     await this.runTimer(roomId, 15000, TimerType.GUESSING);
     const result = await this.gameService.handleGuessingTimeout(roomId);

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -361,6 +361,16 @@ export class GameService {
     const room = await this.gameRepository.getRoom(roomId);
     if (!room) throw new RoomNotFoundException('Room not found');
 
+    // drawing 시간이 종료되면 OCR 및 선 삭제 로직을 수행할 수 있게 RoomStatus를 OCR로 변경
+    await this.gameRepository.updateRoom(roomId, { status: RoomStatus.OCR });
+
+    return RoomStatus.OCR;
+  }
+
+  async handleOCRTimeout(roomId: string) {
+    const room = await this.gameRepository.getRoom(roomId);
+    if (!room) throw new RoomNotFoundException('Room not found');
+
     await this.gameRepository.updateRoom(roomId, { status: RoomStatus.GUESSING });
 
     return RoomStatus.GUESSING;


### PR DESCRIPTION
## 📂 작업 내용

closes #64 

- [x] TimerType 등, 관련 enum에 OCR 추가
- [x] drawing 시간 이후를 OCR 시간으로 변경 및 OCR 시간 이후 guessing을 진행할 수 있게 구현
- [x] drawing 타임에 guessers 화면을 재활용해 ocr 시간에 모든 플레이어에게 타이머 화면을 보여주고, 기다릴 수 있게 함

## 💡 자세한 설명

- TimerType, RoomStatus 등 관련 enum 클래스에 모두 OCR 상태를 추가하였습니다.
- 기존에는 drawing 시간 이후 바로 guessing 시간으로 되어있어 모두가 보는 화면에서 실시간으로 선이 삭제가 됐었는데요... 이 부분을 보완하기 위해 OCR 시간을 추가하고(15초), 해당 시간 동안 구경꾼 전용 타이머를 재활용해서 화면에 보여주는 방식으로 진행했습니다.

## 📗 구현 결과

- 게임 방 내 모든 플레이어에게 동일한 화면을 보여주며, OCR을 기다릴 수 있게 만들었습니다!

https://github.com/user-attachments/assets/061b595e-c9be-4292-8a14-422543c9b672


https://github.com/user-attachments/assets/3eecada0-3938-4298-93d4-95509354668a



## 📢 리뷰 요구 사항

- 사실 근데... 제 마음대로 FE 쪽 코드를 고쳐버려가지고..ㅎㅎ 이렇게 해도 되는건지!! 꼼꼼하게 리뷰 남겨주시면 좋을 거 같아요ㅎㅎ!
- 제가 봤을 때 그림꾼/방해꾼 시점에서 너무 타이머로 바로 확 바뀌는 것 같더라구요. 좀 더 부드럽게 전환하려면 어떻게 해야 하나요?

## 🚩 후속 작업 

- 제 개인적인 생각인데!! **`그림을 분석하는 중...`** 여기서 Clova Studio 해서 연관단어 확인한 다음에 패널티를 주면 딱 좋을 거 같은 시간 같습니다!! FE 쪽에서는 음 토스트 메시지라고 하나요?? 그거로 **`그림 내 부정행위 발견, 패널티를 부과합니다.`** 와 같은 알림 메시지를 주면 어떨까 싶은데 어떻게 생각하시나요?

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
