### PR TITLE
bug/#72 OCR 동작 시간 동안 채팅이 전송되는 오류 수정

### DIFF
--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -32,7 +32,7 @@ export const ChatInput = memo(() => {
 
   const shouldDisableInput = useMemo(() => {
     const ispainters = roundAssignedRole !== PlayerRole.GUESSER;
-    const isDrawing = roomStatus === 'DRAWING' || roomStatus === 'GUESSING';
+    const isDrawing = roomStatus === 'DRAWING' || roomStatus === 'OCR' || roomStatus === 'GUESSING';
     return ispainters && isDrawing;
   }, [roundAssignedRole, roomStatus]);
 


### PR DESCRIPTION
## 📂 작업 내용

closes #72 

- [x] OCR 동작 시간 동안 구경꾼이 아닌 플레이어가 채팅이 쳐지는 문제 수정

## 💡 자세한 설명

```tsx
const shouldDisableInput = useMemo(() => {
  const ispainters = roundAssignedRole !== PlayerRole.GUESSER;
  const isDrawing = roomStatus === 'DRAWING' || roomStatus === 'OCR' || roomStatus === 'GUESSING';
  return ispainters && isDrawing;
}, [roundAssignedRole, roomStatus]);
```

채팅 입력 disable 옵션을 관리하는 변수에 OCR 상태를 추가하여, OCR 상태일 때도 채팅을 칠 수 없게 변경하였습니다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
