### PR TITLE
🏗️build(docker-build/prod/nginx.conf): http 2, 3 버전 활성화

### DIFF
--- a/docker-build/prod/nginx.conf
+++ b/docker-build/prod/nginx.conf
@@ -4,7 +4,12 @@ server {
     return 301 https://$server_name$request_uri;
 }
 server {
-    listen 443 ssl;
+    # http2, 3 on
+    listen 443 ssl http2;
+    listen 443 quic reuseport;
+
+    add_header Alt-Svc 'h3=":$server_port"; ma=86400';
+
     server_name re-troublepainter.kro.kr;
 
     ssl_certificate /etc/letsencrypt/live/re-troublepainter.kro.kr/fullchain.pem;


### PR DESCRIPTION
## 📂 작업 내용

- [x] nginx conf http 2, 3 버전 활성화

## 💡 자세한 설명

### nginx conf http 2, 3 버전 활성화

기존에 http 2, 3버전이 활성화 되지 않은 것을 발견함. 
```shell
curl --head https://re-troublepainter.kro.kr
```
이를 해결하기 위해 nginx 설정을 변경함.

## 📗 참고 자료 & 구현 결과 (선택)
![image](https://github.com/user-attachments/assets/bf9a45fb-9648-4965-b29f-2c43060ce15c)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

ncloud udp 허용

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
