### PR TITLE
Deploy/#74 alpine linux 상에서 의존성 설치하기

### DIFF
--- a/docker-build/dev/Dockerfile.server
+++ b/docker-build/dev/Dockerfile.server
@@ -8,7 +8,7 @@ COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
 COPY core ./core
 COPY server ./server
 
-RUN apk update && apk add build-base g++ cairo-dev pango-dev giflib-dev
+RUN apk add python3 pkgconfig pixman-dev cairo-dev pango-dev build-base libjpeg-turbo-dev
 
 RUN pnpm install --frozen-lockfile
 
@@ -24,7 +24,7 @@ COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/core/package.json ./core/package.json
 COPY --from=builder /app/core/dist ./core/dist
 
-RUN apk update && apk add build-base g++ cairo-dev pango-dev giflib-dev
+RUN apk add python3 pkgconfig pixman-dev cairo-dev pango-dev build-base libjpeg-turbo-dev
 
 RUN corepack enable && corepack prepare pnpm@9.12.3 --activate && cd server && pnpm install --prod --filter '!@troublepainter/core'
 

--- a/docker-build/prod/Dockerfile.server
+++ b/docker-build/prod/Dockerfile.server
@@ -8,7 +8,7 @@ COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.base.json ./
 COPY core ./core
 COPY server ./server
 
-RUN apk update && apk add build-base g++ cairo-dev pango-dev giflib-dev
+RUN apk add python3 pkgconfig pixman-dev cairo-dev pango-dev build-base libjpeg-turbo-dev
 
 RUN pnpm install --frozen-lockfile
 
@@ -24,7 +24,7 @@ COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/core/package.json ./core/package.json
 COPY --from=builder /app/core/dist ./core/dist
 
-RUN apk update && apk add build-base g++ cairo-dev pango-dev giflib-dev
+RUN apk add python3 pkgconfig pixman-dev cairo-dev pango-dev build-base libjpeg-turbo-dev
 
 RUN corepack enable && corepack prepare pnpm@9.12.3 --activate && cd server && pnpm install --prod --filter '!@troublepainter/core'
 


### PR DESCRIPTION
## 📂 작업 내용

- [x] alpine linux 상에서 의존성을 추가(libjpeg)함.

## 💡 자세한 설명

### libjpeg

- canvas에서 의존성인 libjpeg이 빠져있었고, 이를 추가해주었다.

### alpine vs slim image

- alpine 리눅스를 이용해 진행한 것과 debian을 기초로한 slim 이미지상에서 데비안은 1.53gb를 사용해 기존 alpine 리눅스가 사용한 1.2기가보다 더 많은 사용량을 자랑했다;
- alpine 리눅스를 사용하는 방향으로 롤백을 진행했다.
<img width="827" alt="스크린샷 2025-02-13 오후 4 46 27" src="https://github.com/user-attachments/assets/2a7a9afc-b48d-4dc1-a31a-713a4b0468a1" />


## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
