### PR TITLE
refactor: 이미지 스프라이트로 플레이어들의 그림 생성

### DIFF
--- a/server/src/common/services/canvas.service.spec.ts
+++ b/server/src/common/services/canvas.service.spec.ts
@@ -17,11 +17,11 @@ const CRDT_DATAS = Array.from({ length: 10 }, (_, index) => {
             points: [
               {
                 x: index * 100,
-                y: index * 60,
+                y: index * 62.5,
               },
               {
                 x: (index + 1) * 100,
-                y: (index + 1) * 60,
+                y: (index + 1) * 62.5,
               },
             ],
             style: {
@@ -76,18 +76,13 @@ describe('CanvasService', () => {
     });
   });
 
-  describe('getImagesByBase64', () => {
+  describe('generateBase64ImageSprite', () => {
     it('should return base64 encoded images', async () => {
       service.createRoom('room1');
       CRDT_DATAS.forEach((crdtData) => service.applyDrawing('room1', crdtData.drawingData));
 
-      const result = await service.getImagesByBase64('room1');
-      // 개인 캔버스
-      PLAYER_IDS.forEach((playerId) => {
-        expect(typeof result[playerId]).toBe('string');
-      });
-      // 공용 캔버스
-      expect(typeof result['shared']).toBe('string');
+      const result = await service.generateBase64ImageSprite('room1');
+      expect(typeof result).toBe('string');
     }, 20000);
   });
 
@@ -97,61 +92,65 @@ describe('CanvasService', () => {
       CRDT_DATAS.forEach((crdtData) => service.applyDrawing('room1', crdtData.drawingData));
 
       const crdtMessage = service.getEraseLineMessage('room1', [
-        {
-          playerId: '1',
-          boundary: [
-            { x: 0, y: 0 },
-            { x: 1000, y: 0 },
-            { x: 1000, y: 1000 },
-            { x: 0, y: 1000 },
-          ],
-        },
+        [
+          { x: 500, y: 0 },
+          { x: 500, y: 313 },
+          { x: 1000, y: 313 },
+          { x: 1000, y: 0 },
+        ],
       ]);
       expect(Object.keys(crdtMessage.state).length).toBe(4);
     });
 
-    it('remove all stroke', () => {
+    it('remove all strokes by shared boundary', () => {
       service.createRoom('room1');
       CRDT_DATAS.forEach((crdtData) => service.applyDrawing('room1', crdtData.drawingData));
 
       const crdtMessage = service.getEraseLineMessage(
         'room1',
-        PLAYER_IDS.map((playerId) => ({
-          playerId,
-          boundary: [
-            { x: 0, y: 0 },
-            { x: 1000, y: 0 },
-            { x: 1000, y: 1000 },
-            { x: 0, y: 1000 },
-          ],
-        })),
+        PLAYER_IDS.map(() => [
+          { x: 0, y: 0 },
+          { x: 500, y: 0 },
+          { x: 500, y: 313 },
+          { x: 0, y: 313 },
+        ]),
       );
       expect(Object.keys(crdtMessage.state).length).toBe(10);
     });
 
-    it('shared boundary', () => {
+    it('remove some strokes by shared boundary', () => {
+      service.createRoom('room1');
+      CRDT_DATAS.forEach((crdtData) => service.applyDrawing('room1', crdtData.drawingData));
+
+      const crdtMessage = service.getEraseLineMessage(
+        'room1',
+        PLAYER_IDS.map(() => [
+          { x: 10, y: 10 },
+          { x: 10, y: 300 },
+          { x: 490, y: 300 },
+          { x: 490, y: 10 },
+        ]),
+      );
+      expect(Object.keys(crdtMessage.state).length).toBe(8);
+    });
+
+    it('remove shared boundary', () => {
       service.createRoom('room1');
       CRDT_DATAS.forEach((crdtData) => service.applyDrawing('room1', crdtData.drawingData));
 
       const crdtMessage = service.getEraseLineMessage('room1', [
-        {
-          playerId: '1',
-          boundary: [
-            { x: 0, y: 0 },
-            { x: 1000, y: 0 },
-            { x: 1000, y: 1000 },
-            { x: 0, y: 1000 },
-          ],
-        },
-        {
-          playerId: 'shared',
-          boundary: [
-            { x: 0, y: 0 },
-            { x: 1000, y: 0 },
-            { x: 1000, y: 1000 },
-            { x: 0, y: 1000 },
-          ],
-        },
+        [
+          { x: 0, y: 0 },
+          { x: 500, y: 0 },
+          { x: 500, y: 313 },
+          { x: 0, y: 313 },
+        ],
+        [
+          { x: 500, y: 0 },
+          { x: 500, y: 313 },
+          { x: 1000, y: 313 },
+          { x: 1000, y: 0 },
+        ],
       ]);
       expect(Object.keys(crdtMessage.state).length).toBe(4);
     });

--- a/server/src/common/services/canvas.service.ts
+++ b/server/src/common/services/canvas.service.ts
@@ -1,17 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { CRDTMessage, CRDTMessageTypes, CRDTSyncMessage, DrawingData, LWWMap, MapState } from '@troublepainter/core';
-import { Canvas, CanvasRenderingContext2D, createCanvas } from 'canvas';
+import { CanvasRenderingContext2D, createCanvas } from 'canvas';
 
 @Injectable()
 export class CanvasService {
   private crdtMap: Map<string, LWWMap> = new Map();
-  private canvasScale = 0.5;
+  private offsetMap: Map<string, Record<string, { x: number; y: number }>> = new Map();
+  private canvasScale = 0.5 as const;
+  private canvasSize = { w: 1000, h: 625 } as const;
 
   createRoom(roomId: string) {
     this.crdtMap.set(roomId, new LWWMap(roomId));
+    this.offsetMap.set(roomId, {});
   }
   removeRoom(roomID: string) {
     this.crdtMap.delete(roomID);
+    this.offsetMap.delete(roomID);
   }
 
   applyScale(position: { x: number; y: number }) {
@@ -45,80 +49,87 @@ export class CanvasService {
   // 드로잉 데이터를 적용
   applyDrawing(roomId: string, crdtDrawingData: CRDTMessage) {
     const lwwMap = this.crdtMap.get(roomId);
-    if (!lwwMap) return;
+    const offset = this.offsetMap.get(roomId);
+    if (!lwwMap && !offset) return;
 
     if (crdtDrawingData.type === CRDTMessageTypes.UPDATE) {
       const { key, register } = crdtDrawingData.state;
       lwwMap.mergeRegister(key, register);
+      // 오프셋 등록
+      if (!(register.peerId in offset)) {
+        const registeredPlayerCount = Object.keys(offset).length;
+        const offsetX = ((registeredPlayerCount + 1) % 2) * this.canvasSize.w * this.canvasScale;
+        const offsetY = Math.floor((registeredPlayerCount + 1) / 2) * this.canvasSize.h * this.canvasScale;
+        offset[register.peerId] = { x: offsetX, y: offsetY };
+      }
     }
   }
 
-  // 캔버스 이미지를 base64로 변환
-  // shared: 공용 캔버스 / 그외: 각 플레이어의 개인 캔버스
-  async getImagesByBase64(roomId: string): Promise<Record<string, string>> {
+  // 이미지 스프라이트를 생성
+  async generateBase64ImageSprite(roomId: string): Promise<string> | null {
     const lwwMap = this.crdtMap.get(roomId);
-    if (!lwwMap) return;
+    const offset = this.offsetMap.get(roomId);
+    if (!lwwMap && !offset) return;
     const lwwMapState = lwwMap.state;
 
-    const MAINCANVAS_RESOLUTION_WIDTH = Math.ceil(1000 * this.canvasScale);
-    const MAINCANVAS_RESOLUTION_HEIGHT = Math.ceil(625 * this.canvasScale);
+    const canvas = createCanvas(this.canvasSize.w + 100, this.canvasSize.h + 100);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    const sharedCanvas = createCanvas(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
-    // const ctxStart = performance.now();
-    const sharedCtx = sharedCanvas.getContext('2d');
-    // console.log('ctx time:', performance.now() - ctxStart);
-    sharedCtx.fillStyle = 'white';
-    sharedCtx.fillRect(0, 0, MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
-    const individualCanvasMap: Record<string, { canvas: Canvas; ctx: CanvasRenderingContext2D }> = {};
-
-    // 그림 그리기
-    // const drawStart = performance.now();
+    // 공동 그리기
     const activeStrokes = lwwMap.getActiveStrokes();
+    for (const { stroke } of activeStrokes) {
+      if (stroke.points.length > 2) continue;
+      this.drawStroke(ctx, stroke);
+    }
+    // 개별 그리기
+    // ctx.setTransform를 최소화하기 위해 공동 그리기와 분리함
+    let prevPlayerId = null;
     for (const { stroke, id } of activeStrokes) {
       const playerId = lwwMapState[id].peerId;
       if (stroke.points.length > 2) continue; // 채우기는 지나가기
-      this.drawStroke(sharedCtx, stroke);
-      if (!individualCanvasMap[playerId]) {
-        const canvas = createCanvas(MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
-        const ctx = canvas.getContext('2d');
-        ctx.fillStyle = 'white';
-        ctx.fillRect(0, 0, MAINCANVAS_RESOLUTION_WIDTH, MAINCANVAS_RESOLUTION_HEIGHT);
-        individualCanvasMap[playerId] = { canvas, ctx };
-      }
-      this.drawStroke(individualCanvasMap[playerId].ctx, stroke);
+      if (playerId in offset && prevPlayerId !== playerId)
+        ctx.setTransform(1, 0, 0, 1, offset[playerId].x, offset[playerId].y);
+      prevPlayerId = playerId;
+      this.drawStroke(ctx, stroke);
     }
-    // console.log('draw time:', performance.now() - drawStart);
 
-    //그림을 base64 이미지로 변환
-    // const base64Start = performance.now();
-    const canvasList = [sharedCanvas, ...Object.values(individualCanvasMap).map(({ canvas }) => canvas)];
-    const resultKeyList = ['shared', ...Object.keys(individualCanvasMap)];
-    const resultValueList = await Promise.all(
-      canvasList.map(async (canvas) => {
-        const pngData = [];
-        const stream = canvas.createJPEGStream();
-        stream.on('data', (chunk) => pngData.push(chunk));
-        await new Promise((resolve) => stream.on('end', resolve));
-        const buf = Buffer.concat(pngData);
-        return buf.toString('base64');
-      }),
-    );
-    // console.log('base64 time:', performance.now() - base64Start);
-
-    return resultKeyList.reduce((acc, key, idx) => {
-      acc[key] = resultValueList[idx];
-      return acc;
-    }, {});
+    // 이미지를 추출하여 base64로 변환
+    const pngData = [];
+    const stream = canvas.createJPEGStream();
+    await new Promise((resolve, reject) => {
+      stream.on('data', (chunk) => pngData.push(chunk));
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+    const buf = Buffer.concat(pngData);
+    return buf.toString('base64');
   }
 
-  // 지워야하는 CRDT 메시지 반환
-  // 만약 공용 캔버스의 바운더리라면 playerId를 'shared'로 설정
-  getEraseLineMessage(
-    roomId: string,
-    boundaryList: { playerId: string; boundary: { x: number; y: number }[] }[],
-  ): CRDTSyncMessage {
+  // 바운더리에 해당하는 플레이어 아이디를 반환. 없으면 null
+  getPlayerIdByBoundary(roomId: string, boundary: { x: number; y: number }[]): string | null {
+    if (!boundary && boundary.length < 1) return null;
     const lwwMap = this.crdtMap.get(roomId);
-    if (!lwwMap) return;
+    const offset = this.offsetMap.get(roomId);
+    if (!lwwMap && !offset) return null;
+    const sumPoint = boundary.reduce((acc, e) => ({ x: acc.x + e.x, y: acc.y + e.y }), { x: 0, y: 0 });
+    const mx = sumPoint.x / boundary.length;
+    const my = sumPoint.y / boundary.length;
+    const w = this.canvasSize.w * this.canvasScale;
+    const h = this.canvasSize.h * this.canvasScale;
+    const offsetList = Object.entries(offset);
+    for (const [plyaerId, { x, y }] of offsetList) {
+      if (x < mx && mx <= x + w && y < my && my <= y + h) return plyaerId;
+    }
+    return null;
+  }
+
+  // 바운더리 내에 선을 지우는 CRDT 메시지 반환
+  getEraseLineMessage(roomId: string, boundaryList: { x: number; y: number }[][]): CRDTSyncMessage | null {
+    const lwwMap = this.crdtMap.get(roomId);
+    const offset = this.offsetMap.get(roomId);
+    if (!lwwMap && !offset) return;
     const lwwMapState = lwwMap.state;
 
     // 점이 경계 안에 있는지 확인
@@ -131,9 +142,21 @@ export class CanvasService {
       return crossList.every((cross) => cross >= 0) || crossList.every((cross) => cross <= 0);
     };
 
+    // 플레이어아이디: 바운더리배열
+    const boundaryMap = boundaryList.reduce(
+      (acc: { playerId: string; boundary: { x: number; y: number }[] }[], boundary) => {
+        const playerId = this.getPlayerIdByBoundary(roomId, boundary) || 'shared';
+        const offsetPos = offset[playerId];
+        if (offsetPos) boundary = boundary.map((e) => ({ x: e.x - offsetPos.x, y: e.y - offsetPos.y }));
+        acc.push({ playerId, boundary });
+        return acc;
+      },
+      [],
+    );
+
     // 개인 캔버스의 바운더리와 겹치는 공용 캔버스 바운더리 제거
-    const sharedBoundaryList = boundaryList.filter(({ playerId }) => playerId === 'shared');
-    const individualBoundaryList = boundaryList.filter(({ playerId }) => playerId !== 'shared');
+    const sharedBoundaryList = boundaryMap.filter(({ playerId }) => playerId === 'shared');
+    const individualBoundaryList = boundaryMap.filter(({ playerId }) => playerId !== 'shared');
     const filteredSharedBoundaryList = sharedBoundaryList.filter(({ boundary: sharedBoundary }) =>
       individualBoundaryList.every(
         ({ boundary: individualBoundary }) =>
@@ -153,10 +176,10 @@ export class CanvasService {
           return stroke.points.every((strokePoint) => isPointInBoundary(strokePoint, boundary));
         }),
       )
-      .reduce((acc, { id, stroke }) => {
+      .reduce((acc: MapState, { id, stroke }) => {
         acc[id] = { peerId: lwwMapState[id].peerId, timestamp: stroke.timestamp, value: stroke, isDeactivated: true };
         return acc;
-      }, {} as MapState);
+      }, {});
 
     return { type: CRDTMessageTypes.SYNC, state: resultMapState };
   }

--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -157,31 +157,46 @@ export class GameGateway implements OnGatewayDisconnect {
 
     const timerPromise = this.runTimer(roomId, 10000, TimerType.OCR);
 
+    // OCR 작업
     const paneltyList = [];
-    const processingTimerPromise = (async () => {
-      // drawing 시간이 종료되면, 이미지를 base64로 변환
-      const canvasImages = await this.canvasService.getImagesByBase64(roomId);
+    {
+      const imageBase64 = await this.canvasService.generateBase64ImageSprite(roomId);
+      const ocrResult = (await this.clovaOcr.doOCR(imageBase64)) as OCRResult;
+      const fields = ocrResult.images[0].fields;
+      const boundaries = fields.map((field) => field.boundingPoly.vertices);
+      const playerIds = boundaries.map((boundary) => this.canvasService.getPlayerIdByBoundary(roomId, boundary));
+      const words = fields.map((field) => field.inferText);
+      const wordsGroupByPlayerId = words.reduce((acc: Record<string, string[]>, word, index) => {
+        const playerId = playerIds[index];
+        if (!playerId) return acc;
+        if (!(playerId in acc)) acc[playerId] = [];
+        acc[playerId].push(word);
+        return acc;
+      }, {});
+
+      // 패널티 작업
       await Promise.all(
-        Object.entries(canvasImages).map(async ([playerId, imageBase64]) => {
-          const ocrResult = await this.clovaOcr.doOCR(imageBase64);
-          const boundaries = this.getTextBoundaries(ocrResult, playerId);
-
-          // 단어가 존재한다면 영역 내 선 지우기 및 연관 여부 판단하기
-          if (boundaries.length > 0) {
-            // 인식된 단어만 추출
-            const inferTexts = ocrResult.images[0].fields.map((field) => field.inferText);
-            const paneltyWords = await this.filterRelatedWord(currentWord, inferTexts);
-            if (paneltyWords.length > 0) {
-              await this.gameService.applyPenalty(roomId, playerId);
-              paneltyList.push({ playerId, paneltyWords });
-            }
-
-            await this.eraseMessage(roomId, playerId, boundaries);
+        Object.entries(wordsGroupByPlayerId).map(async ([playerId, words]) => {
+          const paneltyWords = await this.filterRelatedWord(currentWord, words);
+          if (paneltyWords.length > 0) {
+            await this.gameService.applyPenalty(roomId, playerId);
+            paneltyList.push({ playerId, paneltyWords });
           }
         }),
       );
-    })();
-    await Promise.all([timerPromise, processingTimerPromise]);
+
+      // 선 삭제
+      const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
+      await this.redisService.publish(
+        `erasing:${roomId}`,
+        JSON.stringify({
+          playerId: '*',
+          drawingData: eraseMessage,
+        }),
+      );
+    }
+
+    await timerPromise;
 
     // OCR 및 선 삭제 로직이 종료된 이후 추측 시간으로 변경
     roomStatus = await this.gameService.handleOCRTimeout(roomId);
@@ -323,31 +338,6 @@ export class GameGateway implements OnGatewayDisconnect {
     }
   }
 
-  private getTextBoundaries(ocrResult: OCRResult, playerId: string) {
-    return (
-      ocrResult.images[0].fields.map((field) => ({
-        playerId,
-        boundary: [
-          { x: field.boundingPoly.vertices[0].x, y: field.boundingPoly.vertices[0].y },
-          { x: field.boundingPoly.vertices[1].x, y: field.boundingPoly.vertices[1].y },
-          { x: field.boundingPoly.vertices[2].x, y: field.boundingPoly.vertices[2].y },
-          { x: field.boundingPoly.vertices[3].x, y: field.boundingPoly.vertices[3].y },
-        ],
-      })) || []
-    );
-  }
-
-  private async eraseMessage(roomId: string, playerId: string, boundaries: TextBoundary[]) {
-    const eraseMessage = this.canvasService.getEraseLineMessage(roomId, boundaries);
-    await this.redisService.publish(
-      `erasing:${roomId}`,
-      JSON.stringify({
-        playerId,
-        drawingData: eraseMessage,
-      }),
-    );
-  }
-
   // 캔버스 내 인식된 단어 중 제시어와 연관된 단어들을 배열로 반환.
   private async filterRelatedWord(suggestedWord: string, inferTexts: string[]) {
     const isRelatedList = await Promise.all(
@@ -383,14 +373,4 @@ interface OCRResult {
       lineBreak: boolean;
     }>;
   }>;
-}
-
-interface Point {
-  x: number;
-  y: number;
-}
-
-interface TextBoundary {
-  playerId: string;
-  boundary: Point[];
 }


### PR DESCRIPTION
## 📂 작업 내용

closes #90 

- [x] 이미지 스프라이트로 이미지 생성

![image](https://github.com/user-attachments/assets/f8fb4e68-3339-4057-b617-e77be4f9a974)

## 💡 자세한 설명

- 플레이어 별로 오프셋 관리
- 특정 좌표에 플레이어 오프셋을 적용하는 함수
- 오프셋이 적용된 바운더리로 플레이어를 식별하는 함수
- 이미지 스프라이트 생성하는 함수
- 바운더리를 받아 선을 제거하는 CRDT 메시지 생성하는 함수

(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 & 구현 결과 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (`main`이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
